### PR TITLE
Correctly eval cdr

### DIFF
--- a/README.org
+++ b/README.org
@@ -1694,6 +1694,7 @@ If you want to request explicitly use the ~:require t~ flag.
 ** Contributors
 - Kzflute ([[https://github.com/Kzflute][Kzflute]])
 - KeenS ([[https://github.com/KeenS][κeen]])
+- Dario Gjorgjevski ([[https://github.com/d125q][d125q]])
 
 ** Special Thanks
 Advice and comments given by [[http://emacs-jp.github.io/][Emacs-JP]]'s forum member has been a great help  in developing ~leaf.el~.

--- a/README.org
+++ b/README.org
@@ -335,7 +335,12 @@ you can also use ~:ensure~ as ~:package~.
          (leaf-handler-package leaf feather nil)
          (leaf-handler-package leaf leaf-key nil)
          (leaf-handler-package leaf leaf-browser nil)
-         (leaf-init)))))
+         (leaf-init)))
+
+    ((leaf leaf
+       :package (t . pin))
+     (prog1 'leaf
+       (leaf-handler-package leaf leaf pin)))))
 
   (cort-deftest-with-macroexpand leaf/handler-package
     '(((leaf macrostep :ensure t)

--- a/leaf-tests.el
+++ b/leaf-tests.el
@@ -274,7 +274,12 @@ Example:
        (leaf-handler-package leaf feather nil)
        (leaf-handler-package leaf leaf-key nil)
        (leaf-handler-package leaf leaf-browser nil)
-       (leaf-init)))))
+       (leaf-init)))
+
+    ((leaf leaf
+       :package (t . pin))
+     (prog1 'leaf
+       (leaf-handler-package leaf leaf pin)))))
 
 (cort-deftest-with-macroexpand leaf/doc
   '(((leaf leaf

--- a/leaf.el
+++ b/leaf.el
@@ -306,7 +306,7 @@ Sort by `leaf-sort-leaf--values-plist' in this order.")
      (mapcar (lambda (elm)
                (cond
                 ((leaf-pairp elm)
-                 (if (eq t (car elm)) `(,leaf--name . (cdr elm)) elm))
+                 (if (eq t (car elm)) `(,leaf--name . ,(cdr elm)) elm))
                 ((memq leaf--key '(:ensure :package))
                  (if (eq t elm) `(,leaf--name . nil) `(,elm . nil)))
                 ((memq leaf--key '(:hook :mode :interpreter :magic :magic-fallback :defun))

--- a/leaf.el
+++ b/leaf.el
@@ -5,7 +5,7 @@
 ;; Author: Naoya Yamashita <conao3@gmail.com>
 ;; Maintainer: Naoya Yamashita <conao3@gmail.com>
 ;; Keywords: lisp settings
-;; Version: 3.3.2
+;; Version: 3.3.3
 ;; URL: https://github.com/conao3/leaf.el
 ;; Package-Requires: ((emacs "24.4"))
 


### PR DESCRIPTION
## Description

Currently,

    (leaf some-mode
      :hook (t . other-mode))

macroexpands to

    (prog1 'some-mode
      (leaf-handler-leaf-protect some-mode
        (autoload #'(cdr elm) "some-mode" nil t)
        (add-hook 'some-mode #'(cdr elm))))

while the expected result is

    (prog1 'some-mode
      (leaf-handler-leaf-protect some-mode
        (autoload #'other-mode "some-mode" nil t)
        (add-hook 'some-mode #'other-mode)))

## Checklist
<!-- Please confirm with `x` -->
- [x] I've read [CONTRIBUTING.org](https://github.com/conao3/leaf.el/blob/master/CONTRIBUTING.org).
  - [x] I've assign FSF.
  - [x] The leaf.el after my changed pass all testcases by `make test`.
  - [x] My changed elisp code byte-compiled cleanly.
  - [x] I've added testcases related to my PR.
  - [x] I've fixed README related the my added testcases.
