### PR TITLE
Implement plstore-related keywords

### DIFF
--- a/README.org
+++ b/README.org
@@ -1517,11 +1517,10 @@ Before those keyword using, prepare below plstore data and store it.
 #+end_src
 
 If you save plist file named as ~~/.emacs.d/plstore.plist~, open plstore file and decription if needed (then type password).
-(Because we want this ~setq~ to be evaluated at run time, you must use the ~:config~ keyword and explicitly write the S-expression.)
+
 #+begin_src emacs-lisp
   (leaf plstore
-    :config
-    (setq some-plstore (plstore-open (expand-file-name "~/.emacs.d/plstore.plist"))))
+    :setq `(some-plstore . ,(plstore-open (expand-file-name "~/.emacs.d/plstore.plist"))))
 #+end_src
 
 ~leaf~ expand ~plstore~ related keywords as below.

--- a/README.org
+++ b/README.org
@@ -42,6 +42,8 @@
   - [[https://github.com/conao3/leaf.el#defun-defvar-keywords][:defun, :defvar keywords]]
 - [[https://github.com/conao3/leaf.el#documentation-keywords][Documentation keywords]]
   - [[https://github.com/conao3/leaf.el#doc-file-url-keywords][:doc, :file, :url keywords]]
+- [[https://github.com/conao3/leaf.el#misc-keywords][Misc keywords]]
+  - [[https://github.com/conao3/leaf.el#pl-pre-setq-pl-setq-pl-setq-default-pl-custom-keywords][:pl-pre-setq, :pl-setq, :pl-setq-default, :pl-custom keywords]]
 - [[#system-keywords][System keywords]]
   - [[#leaf-protect-keyword][:leaf-protect keyword]]
   - [[#leaf-defer-keyword][:leaf-defer keyword]]
@@ -1479,6 +1481,142 @@ The arguments specified for this keyword have no effect on the result of the con
        (prog1 'leaf
          (leaf-init)))))
 #+END_SRC
+* Misc keywords
+** :pl-pre-setq, :pl-setq, :pl-setq-default, :pl-custom keywords
+Those keywords provide configure variables with [[https://github.com/emacs-mirror/emacs/blob/master/lisp/plstore.el][plstore.el]].
+~plstore~ provide plist based data managing and encryption.
+
+The keywords for plstore corresponding to ~:pre-setq~, ~:setq~, ~:setq-default~ and ~:custom~ are
+~:pl-pre-setq~, ~:pl-setq~, ~:pl-setq-default~ and ~:pl-custom~.
+
+Before those keyword using, prepare below plstore data and store it.
+
+#+begin_src emacs-lisp
+  (("leaf-sql"
+    :secret-sql-connection-alist (("Postgres/d125q"
+                                   (sql-product 'postgres)
+                                   (sql-user "d125q")
+                                   (sql-password "password")
+                                   (sql-server "server")
+                                   (sql-port 5432)
+                                   (sql-database "database"))
+                                  ("MySQL/d125q"
+                                   (sql-product 'mysql)
+                                   (sql-user "d125q")
+                                   (sql-password "password")
+                                   (sql-server "server")
+                                   (sql-port 3306)
+                                   (sql-database "database"))))
+   ("leaf-erc"
+    :secret-erc-password           "password"
+    :secret-erc-nickserv-passwords '((freenode (("nick-one" . "password")
+                                                ("nick-two" . "password")))
+                                     (DALnet   (("nickname" . "password"))))
+    :secret-erc-user-full-name     "Naoya Yamashita"
+    :secret-erc-nick               "conao3")))
+#+end_src
+
+If you save plist file named as ~~/.emacs.d/plstore.plist~, open plstore file and decription if needed (then type password).
+(Because we want this ~setq~ to be evaluated at run time, you must use the ~:config~ keyword and explicitly write the S-expression.)
+#+begin_src emacs-lisp
+  (leaf plstore
+    :config
+    (setq some-plstore (plstore-open (expand-file-name "~/.emacs.d/plstore.plist"))))
+#+end_src
+
+~leaf~ expand ~plstore~ related keywords as below.
+Before using those keywords, we recommended that you check how ~plstore~ works in ~*scratch*~ and not through ~leaf~.
+
+#+begin_src emacs-lisp
+  (cort-deftest-with-macroexpand leaf/pl-custom
+    ;; Emulate customizing `sql-connection-alist' with value taken from
+    ;; `some-plstore'.
+    '(((leaf sql
+         :pl-custom
+         (sql-connection-alist . some-plstore))
+       (prog1 'sql
+         (custom-set-variables
+          '(sql-connection-alist
+            (plist-get
+             (cdr
+              (plstore-get some-plstore "leaf-sql"))
+             :sql-connection-alist)
+            "Customized in leaf `sql' from plstore `some-plstore'"))))
+      ;; Emulate customizing `erc-password' and `erc-nickserv-passwords'
+      ;; with values taken from `some-plstore', and `erc-user-full-name'
+      ;; and `erc-nick' with values taken from `another-plstore'.
+      ((leaf erc
+         :pl-custom
+         ((erc-password erc-nickserv-passwords) . some-plstore)
+         ((erc-user-full-name erc-nick) . another-plstore))
+       (prog1 'erc
+         (custom-set-variables
+          '(erc-password
+            (plist-get
+             (cdr
+              (plstore-get some-plstore "leaf-erc"))
+             :erc-password)
+            "Customized in leaf `erc' from plstore `some-plstore'")
+          '(erc-nickserv-passwords
+            (plist-get
+             (cdr
+              (plstore-get some-plstore "leaf-erc"))
+             :erc-nickserv-passwords)
+            "Customized in leaf `erc' from plstore `some-plstore'")
+          '(erc-user-full-name
+            (plist-get
+             (cdr
+              (plstore-get another-plstore "leaf-erc"))
+             :erc-user-full-name)
+            "Customized in leaf `erc' from plstore `another-plstore'")
+          '(erc-nick
+            (plist-get
+             (cdr
+              (plstore-get another-plstore "leaf-erc"))
+             :erc-nick)
+            "Customized in leaf `erc' from plstore `another-plstore'"))))))
+
+  (cort-deftest-with-macroexpand leaf/pl-setq
+    ;; Emulate setting `sql-connection-alist' with value taken from
+    ;; `some-plstore'.
+    '(((leaf sql
+         :pl-setq
+         (sql-connection-alist . some-plstore))
+       (prog1 'sql
+         (setq sql-connection-alist
+               (plist-get
+                (cdr
+                 (plstore-get some-plstore "leaf-sql"))
+                :sql-connection-alist))))
+      ;; Emulate setting `erc-password' and `erc-nickserv-passwords'
+      ;; with values taken from `some-plstore', and `erc-user-full-name'
+      ;; and `erc-nick' with values taken from `another-plstore'.
+      ((leaf erc
+         :pl-setq
+         ((erc-password erc-nickserv-passwords) . some-plstore)
+         ((erc-user-full-name erc-nick) . another-plstore))
+       (prog1 'erc
+         (setq erc-password
+               (plist-get
+                (cdr
+                 (plstore-get some-plstore "leaf-erc"))
+                :erc-password))
+         (setq erc-nickserv-passwords
+               (plist-get
+                (cdr
+                 (plstore-get some-plstore "leaf-erc"))
+                :erc-nickserv-passwords))
+         (setq erc-user-full-name
+               (plist-get
+                (cdr
+                 (plstore-get another-plstore "leaf-erc"))
+                :erc-user-full-name))
+         (setq erc-nick
+               (plist-get
+                (cdr
+                 (plstore-get another-plstore "leaf-erc"))
+                :erc-nick))))))
+#+end_src
 
 * System keywords
 System keywords enabled by defalts on all leaf-block.

--- a/leaf-tests.el
+++ b/leaf-tests.el
@@ -718,6 +718,55 @@ Example:
         '(default ((t (:slant italic))))
         '(eruby-standard-face ((t (:slant italic)))))))))
 
+;; Tests for `:pl-custom'.
+(cort-deftest-with-macroexpand leaf/pl-custom
+  ;; Emulate customizing `sql-connection-alist' with value taken from
+  ;; `some-plstore'.
+  '(((leaf sql
+       :pl-custom
+       (sql-connection-alist . some-plstore))
+     (prog1 'sql
+       (custom-set-variables
+	'(sql-connection-alist
+	  (plist-get
+	   (cdr
+	    (plstore-get some-plstore "sql"))
+	   :sql-connection-alist)
+	  "Customized in leaf `sql' from plstore `some-plstore'"))))
+    ;; Emulate customizing `erc-password' and `erc-nickserv-passwords'
+    ;; with values taken from `some-plstore', and `erc-user-full-name'
+    ;; and `erc-nick' with values taken from `another-plstore'.
+    ((leaf erc
+       :pl-custom
+       ((erc-password erc-nickserv-passwords) . some-plstore)
+       ((erc-user-full-name erc-nick) . another-plstore))
+     (prog1 'erc
+       (custom-set-variables
+	'(erc-password
+	  (plist-get
+	   (cdr
+	    (plstore-get some-plstore "erc"))
+	   :erc-password)
+	  "Customized in leaf `erc' from plstore `some-plstore'")
+	'(erc-nickserv-passwords
+	  (plist-get
+	   (cdr
+	    (plstore-get some-plstore "erc"))
+	   :erc-nickserv-passwords)
+	  "Customized in leaf `erc' from plstore `some-plstore'")
+	'(erc-user-full-name
+	  (plist-get
+	   (cdr
+	    (plstore-get another-plstore "erc"))
+	   :erc-user-full-name)
+	  "Customized in leaf `erc' from plstore `another-plstore'")
+	'(erc-nick
+	  (plist-get
+	   (cdr
+	    (plstore-get another-plstore "erc"))
+	   :erc-nick)
+	  "Customized in leaf `erc' from plstore `another-plstore'"))))))
+
 (cort-deftest-with-macroexpand leaf/bind
   '(((leaf macrostep
        :package t
@@ -1474,6 +1523,48 @@ Example:
        (setq leaf-backend-bind 'bind-key)
        (setq leaf-backend-bind* 'bind-key)))))
 
+;; Tests for `:pl-setq'.
+(cort-deftest-with-macroexpand leaf/pl-setq
+  ;; Emulate setting `sql-connection-alist' with value taken from
+  ;; `some-plstore'.
+  '(((leaf sql
+       :pl-setq
+       (sql-connection-alist . some-plstore))
+     (prog1 'sql
+       (setq sql-connection-alist
+	     (plist-get
+	      (cdr
+	       (plstore-get some-plstore "sql"))
+	      :sql-connection-alist))))
+    ;; Emulate setting `erc-password' and `erc-nickserv-passwords'
+    ;; with values taken from `some-plstore', and `erc-user-full-name'
+    ;; and `erc-nick' with values taken from `another-plstore'.
+    ((leaf erc
+       :pl-setq
+       ((erc-password erc-nickserv-passwords) . some-plstore)
+       ((erc-user-full-name erc-nick) . another-plstore))
+     (prog1 'erc
+       (setq erc-password
+	     (plist-get
+	      (cdr
+	       (plstore-get some-plstore "erc"))
+	      :erc-password)
+	     erc-nickserv-passwords
+	     (plist-get
+	      (cdr
+	       (plstore-get some-plstore "erc"))
+	      :erc-nickserv-passwords)
+	     erc-user-full-name
+	     (plist-get
+	      (cdr
+	       (plstore-get another-plstore "erc"))
+	      :erc-user-full-name)
+	     erc-nick
+	     (plist-get
+	      (cdr
+	       (plstore-get another-plstore "erc"))
+	      :erc-nick))))))
+
 (cort-deftest-with-macroexpand leaf/setq-default
   '(((leaf alloc
        :setq-default `((gc-cons-threshold . ,(* 512 1024 1024))
@@ -1510,6 +1601,20 @@ Example:
        (require 'leaf)
        (setq-default leaf-backend-bind 'bind-key)
        (setq-default leaf-backend-bind* 'bind-key)))))
+
+;; Tests for `:pl-setq-default'.
+(cort-deftest-with-macroexpand leaf/pl-setq-default
+  ;; Emulate setting `indent-tabs-mode' with a default value taken
+  ;; from `some-plstore'.
+  '(((leaf indent
+       :pl-setq-default
+       (indent-tabs-mode . some-plstore))
+     (prog1 'indent
+       (setq-default indent-tabs-mode
+		     (plist-get
+		      (cdr
+		       (plstore-get some-plstore "indent"))
+		      :indent-tabs-mode))))))
 
 (cort-deftest-with-macroexpand leaf/config
   '(((leaf leaf

--- a/leaf-tests.el
+++ b/leaf-tests.el
@@ -727,12 +727,12 @@ Example:
        (sql-connection-alist . some-plstore))
      (prog1 'sql
        (custom-set-variables
-	'(sql-connection-alist
-	  (plist-get
-	   (cdr
-	    (plstore-get some-plstore "sql"))
-	   :sql-connection-alist)
-	  "Customized in leaf `sql' from plstore `some-plstore'"))))
+        '(sql-connection-alist
+          (plist-get
+           (cdr
+            (plstore-get some-plstore "sql"))
+           :sql-connection-alist)
+          "Customized in leaf `sql' from plstore `some-plstore'"))))
     ;; Emulate customizing `erc-password' and `erc-nickserv-passwords'
     ;; with values taken from `some-plstore', and `erc-user-full-name'
     ;; and `erc-nick' with values taken from `another-plstore'.
@@ -742,30 +742,30 @@ Example:
        ((erc-user-full-name erc-nick) . another-plstore))
      (prog1 'erc
        (custom-set-variables
-	'(erc-password
-	  (plist-get
-	   (cdr
-	    (plstore-get some-plstore "erc"))
-	   :erc-password)
-	  "Customized in leaf `erc' from plstore `some-plstore'")
-	'(erc-nickserv-passwords
-	  (plist-get
-	   (cdr
-	    (plstore-get some-plstore "erc"))
-	   :erc-nickserv-passwords)
-	  "Customized in leaf `erc' from plstore `some-plstore'")
-	'(erc-user-full-name
-	  (plist-get
-	   (cdr
-	    (plstore-get another-plstore "erc"))
-	   :erc-user-full-name)
-	  "Customized in leaf `erc' from plstore `another-plstore'")
-	'(erc-nick
-	  (plist-get
-	   (cdr
-	    (plstore-get another-plstore "erc"))
-	   :erc-nick)
-	  "Customized in leaf `erc' from plstore `another-plstore'"))))))
+        '(erc-password
+          (plist-get
+           (cdr
+            (plstore-get some-plstore "erc"))
+           :erc-password)
+          "Customized in leaf `erc' from plstore `some-plstore'")
+        '(erc-nickserv-passwords
+          (plist-get
+           (cdr
+            (plstore-get some-plstore "erc"))
+           :erc-nickserv-passwords)
+          "Customized in leaf `erc' from plstore `some-plstore'")
+        '(erc-user-full-name
+          (plist-get
+           (cdr
+            (plstore-get another-plstore "erc"))
+           :erc-user-full-name)
+          "Customized in leaf `erc' from plstore `another-plstore'")
+        '(erc-nick
+          (plist-get
+           (cdr
+            (plstore-get another-plstore "erc"))
+           :erc-nick)
+          "Customized in leaf `erc' from plstore `another-plstore'"))))))
 
 (cort-deftest-with-macroexpand leaf/bind
   '(((leaf macrostep
@@ -1532,10 +1532,10 @@ Example:
        (sql-connection-alist . some-plstore))
      (prog1 'sql
        (setq sql-connection-alist
-	     (plist-get
-	      (cdr
-	       (plstore-get some-plstore "sql"))
-	      :sql-connection-alist))))
+             (plist-get
+              (cdr
+               (plstore-get some-plstore "sql"))
+              :sql-connection-alist))))
     ;; Emulate setting `erc-password' and `erc-nickserv-passwords'
     ;; with values taken from `some-plstore', and `erc-user-full-name'
     ;; and `erc-nick' with values taken from `another-plstore'.
@@ -1545,25 +1545,25 @@ Example:
        ((erc-user-full-name erc-nick) . another-plstore))
      (prog1 'erc
        (setq erc-password
-	     (plist-get
-	      (cdr
-	       (plstore-get some-plstore "erc"))
-	      :erc-password)
-	     erc-nickserv-passwords
-	     (plist-get
-	      (cdr
-	       (plstore-get some-plstore "erc"))
-	      :erc-nickserv-passwords)
-	     erc-user-full-name
-	     (plist-get
-	      (cdr
-	       (plstore-get another-plstore "erc"))
-	      :erc-user-full-name)
-	     erc-nick
-	     (plist-get
-	      (cdr
-	       (plstore-get another-plstore "erc"))
-	      :erc-nick))))))
+             (plist-get
+              (cdr
+               (plstore-get some-plstore "erc"))
+              :erc-password)
+             erc-nickserv-passwords
+             (plist-get
+              (cdr
+               (plstore-get some-plstore "erc"))
+              :erc-nickserv-passwords)
+             erc-user-full-name
+             (plist-get
+              (cdr
+               (plstore-get another-plstore "erc"))
+              :erc-user-full-name)
+             erc-nick
+             (plist-get
+              (cdr
+               (plstore-get another-plstore "erc"))
+              :erc-nick))))))
 
 (cort-deftest-with-macroexpand leaf/setq-default
   '(((leaf alloc
@@ -1611,10 +1611,10 @@ Example:
        (indent-tabs-mode . some-plstore))
      (prog1 'indent
        (setq-default indent-tabs-mode
-		     (plist-get
-		      (cdr
-		       (plstore-get some-plstore "indent"))
-		      :indent-tabs-mode))))))
+                     (plist-get
+                      (cdr
+                       (plstore-get some-plstore "indent"))
+                      :indent-tabs-mode))))))
 
 (cort-deftest-with-macroexpand leaf/config
   '(((leaf leaf

--- a/leaf-tests.el
+++ b/leaf-tests.el
@@ -1616,6 +1616,20 @@ Example:
                        (plstore-get some-plstore "leaf-indent"))
                       :indent-tabs-mode))))))
 
+(cort-deftest-with-macroexpand leaf/pl-pre-setq
+  ;; Emulate setting `indent-tabs-mode' with a default value taken
+  ;; from `some-plstore'.
+  '(((leaf indent
+       :pl-pre-setq (indent-tabs-mode . some-plstore)
+       :require t)
+     (prog1 'indent
+       (setq indent-tabs-mode
+             (plist-get
+              (cdr
+               (plstore-get some-plstore "leaf-indent"))
+              :indent-tabs-mode))
+       (require 'indent)))))
+
 (cort-deftest-with-macroexpand leaf/config
   '(((leaf leaf
        :init (leaf-pre-init)

--- a/leaf-tests.el
+++ b/leaf-tests.el
@@ -730,7 +730,7 @@ Example:
         '(sql-connection-alist
           (plist-get
            (cdr
-            (plstore-get some-plstore "sql"))
+            (plstore-get some-plstore "leaf-sql"))
            :sql-connection-alist)
           "Customized in leaf `sql' from plstore `some-plstore'"))))
     ;; Emulate customizing `erc-password' and `erc-nickserv-passwords'
@@ -745,25 +745,25 @@ Example:
         '(erc-password
           (plist-get
            (cdr
-            (plstore-get some-plstore "erc"))
+            (plstore-get some-plstore "leaf-erc"))
            :erc-password)
           "Customized in leaf `erc' from plstore `some-plstore'")
         '(erc-nickserv-passwords
           (plist-get
            (cdr
-            (plstore-get some-plstore "erc"))
+            (plstore-get some-plstore "leaf-erc"))
            :erc-nickserv-passwords)
           "Customized in leaf `erc' from plstore `some-plstore'")
         '(erc-user-full-name
           (plist-get
            (cdr
-            (plstore-get another-plstore "erc"))
+            (plstore-get another-plstore "leaf-erc"))
            :erc-user-full-name)
           "Customized in leaf `erc' from plstore `another-plstore'")
         '(erc-nick
           (plist-get
            (cdr
-            (plstore-get another-plstore "erc"))
+            (plstore-get another-plstore "leaf-erc"))
            :erc-nick)
           "Customized in leaf `erc' from plstore `another-plstore'"))))))
 
@@ -1534,7 +1534,7 @@ Example:
        (setq sql-connection-alist
              (plist-get
               (cdr
-               (plstore-get some-plstore "sql"))
+               (plstore-get some-plstore "leaf-sql"))
               :sql-connection-alist))))
     ;; Emulate setting `erc-password' and `erc-nickserv-passwords'
     ;; with values taken from `some-plstore', and `erc-user-full-name'
@@ -1547,22 +1547,22 @@ Example:
        (setq erc-password
              (plist-get
               (cdr
-               (plstore-get some-plstore "erc"))
+               (plstore-get some-plstore "leaf-erc"))
               :erc-password))
        (setq erc-nickserv-passwords
              (plist-get
               (cdr
-               (plstore-get some-plstore "erc"))
+               (plstore-get some-plstore "leaf-erc"))
               :erc-nickserv-passwords))
        (setq erc-user-full-name
              (plist-get
               (cdr
-               (plstore-get another-plstore "erc"))
+               (plstore-get another-plstore "leaf-erc"))
               :erc-user-full-name))
        (setq erc-nick
              (plist-get
               (cdr
-               (plstore-get another-plstore "erc"))
+               (plstore-get another-plstore "leaf-erc"))
               :erc-nick))))))
 
 (cort-deftest-with-macroexpand leaf/setq-default
@@ -1613,7 +1613,7 @@ Example:
        (setq-default indent-tabs-mode
                      (plist-get
                       (cdr
-                       (plstore-get some-plstore "indent"))
+                       (plstore-get some-plstore "leaf-indent"))
                       :indent-tabs-mode))))))
 
 (cort-deftest-with-macroexpand leaf/config

--- a/leaf-tests.el
+++ b/leaf-tests.el
@@ -1548,18 +1548,18 @@ Example:
              (plist-get
               (cdr
                (plstore-get some-plstore "erc"))
-              :erc-password)
-             erc-nickserv-passwords
+              :erc-password))
+       (setq erc-nickserv-passwords
              (plist-get
               (cdr
                (plstore-get some-plstore "erc"))
-              :erc-nickserv-passwords)
-             erc-user-full-name
+              :erc-nickserv-passwords))
+       (setq erc-user-full-name
              (plist-get
               (cdr
                (plstore-get another-plstore "erc"))
-              :erc-user-full-name)
-             erc-nick
+              :erc-user-full-name))
+       (setq erc-nick
              (plist-get
               (cdr
                (plstore-get another-plstore "erc"))

--- a/leaf.el
+++ b/leaf.el
@@ -286,16 +286,16 @@ Unlike `butlast', it works well with dotlist (last cdr is non-nil list)."
 
      ;; Pre-`setq' variables from a plstore.
      :pl-pre-setq
-     `((setq
-        ,@(mapcan
-           (lambda (elm)
-             `(,(car elm)               ; Variable.
-               (plist-get               ; Value.
-                (cdr (plstore-get
-                      ,(cdr elm)
-                      ,(symbol-name leaf--name)))
-                ,(intern (concat ":" (symbol-name (car elm)))))))
-           leaf--value))
+     `(,@(mapcar
+          (lambda (elm)
+            `(setq
+              ,(car elm)               ; Variable.
+              (plist-get               ; Value.
+               (cdr (plstore-get
+                     ,(cdr elm)
+                     ,(symbol-name leaf--name)))
+               ,(intern (concat ":" (symbol-name (car elm)))))))
+          leaf--value)
        ,@leaf--body)
 
      :init           `(,@leaf--value ,@leaf--body)
@@ -327,30 +327,30 @@ Unlike `butlast', it works well with dotlist (last cdr is non-nil list)."
 
      ;; `setq' variables from a plstore.
      :pl-setq
-     `((setq
-        ,@(mapcan
-           (lambda (elm)
-             `(,(car elm)               ; Variable.
-               (plist-get               ; Value.
-                (cdr (plstore-get
-                      ,(cdr elm)
-                      ,(symbol-name leaf--name)))
-                ,(intern (concat ":" (symbol-name (car elm)))))))
-           leaf--value))
+     `(,@(mapcar
+          (lambda (elm)
+            `(setq
+              ,(car elm)               ; Variable.
+              (plist-get               ; Value.
+               (cdr (plstore-get
+                     ,(cdr elm)
+                     ,(symbol-name leaf--name)))
+               ,(intern (concat ":" (symbol-name (car elm)))))))
+          leaf--value)
        ,@leaf--body)
 
      ;; `setq-default' variables from a plstore.
      :pl-setq-default
-     `((setq-default
-        ,@(mapcan
-           (lambda (elm)
-             `(,(car elm)               ; Variable.
-               (plist-get               ; Value.
-                (cdr (plstore-get
-                      ,(cdr elm)
-                      ,(symbol-name leaf--name)))
-                ,(intern (concat ":" (symbol-name (car elm)))))))
-           leaf--value))
+     `(,@(mapcar
+          (lambda (elm)
+            `(setq-default
+              ,(car elm)               ; Variable.
+              (plist-get               ; Value.
+               (cdr (plstore-get
+                     ,(cdr elm)
+                     ,(symbol-name leaf--name)))
+               ,(intern (concat ":" (symbol-name (car elm)))))))
+          leaf--value)
        ,@leaf--body)
 
      :config         `(,@leaf--value ,@leaf--body)

--- a/leaf.el
+++ b/leaf.el
@@ -293,7 +293,7 @@ Unlike `butlast', it works well with dotlist (last cdr is non-nil list)."
               (plist-get               ; Value.
                (cdr (plstore-get
                      ,(cdr elm)
-                     ,(symbol-name leaf--name)))
+                     ,(concat "leaf-" (symbol-name leaf--name))))
                ,(intern (concat ":" (symbol-name (car elm)))))))
           leaf--value)
        ,@leaf--body)
@@ -314,7 +314,7 @@ Unlike `butlast', it works well with dotlist (last cdr is non-nil list)."
                 (plist-get              ; Value.
                  (cdr (plstore-get
                        ,(cdr elm)
-                       ,(symbol-name leaf--name)))
+		       ,(concat "leaf-" (symbol-name leaf--name))))
                  ,(intern (concat ":" (symbol-name (car elm)))))
                 ,(format                ; Comment.
                   "Customized in leaf `%s' from plstore `%s'"
@@ -334,7 +334,7 @@ Unlike `butlast', it works well with dotlist (last cdr is non-nil list)."
               (plist-get               ; Value.
                (cdr (plstore-get
                      ,(cdr elm)
-                     ,(symbol-name leaf--name)))
+		     ,(concat "leaf-" (symbol-name leaf--name))))
                ,(intern (concat ":" (symbol-name (car elm)))))))
           leaf--value)
        ,@leaf--body)
@@ -348,7 +348,7 @@ Unlike `butlast', it works well with dotlist (last cdr is non-nil list)."
               (plist-get               ; Value.
                (cdr (plstore-get
                      ,(cdr elm)
-                     ,(symbol-name leaf--name)))
+		     ,(concat "leaf-" (symbol-name leaf--name))))
                ,(intern (concat ":" (symbol-name (car elm)))))))
           leaf--value)
        ,@leaf--body)

--- a/leaf.el
+++ b/leaf.el
@@ -5,7 +5,7 @@
 ;; Author: Naoya Yamashita <conao3@gmail.com>
 ;; Maintainer: Naoya Yamashita <conao3@gmail.com>
 ;; Keywords: lisp settings
-;; Version: 3.3.5
+;; Version: 3.3.6
 ;; URL: https://github.com/conao3/leaf.el
 ;; Package-Requires: ((emacs "24.4"))
 

--- a/leaf.el
+++ b/leaf.el
@@ -293,8 +293,8 @@ Unlike `butlast', it works well with dotlist (last cdr is non-nil list)."
               (plist-get               ; Value.
                (cdr (plstore-get
                      ,(cdr elm)
-                     ,(concat "leaf-" (symbol-name leaf--name))))
-               ,(intern (concat ":" (symbol-name (car elm)))))))
+		     ,(format "leaf-%s" leaf--name)))
+               ,(intern (format ":%s" (car elm))))))
           leaf--value)
        ,@leaf--body)
 
@@ -314,8 +314,8 @@ Unlike `butlast', it works well with dotlist (last cdr is non-nil list)."
                 (plist-get              ; Value.
                  (cdr (plstore-get
                        ,(cdr elm)
-		       ,(concat "leaf-" (symbol-name leaf--name))))
-                 ,(intern (concat ":" (symbol-name (car elm)))))
+		       ,(format "leaf-%s" leaf--name)))
+		 ,(intern (format ":%s" (car elm))))
                 ,(format                ; Comment.
                   "Customized in leaf `%s' from plstore `%s'"
                   leaf--name (symbol-name (cdr elm)))))
@@ -334,8 +334,8 @@ Unlike `butlast', it works well with dotlist (last cdr is non-nil list)."
               (plist-get               ; Value.
                (cdr (plstore-get
                      ,(cdr elm)
-		     ,(concat "leaf-" (symbol-name leaf--name))))
-               ,(intern (concat ":" (symbol-name (car elm)))))))
+		     ,(format "leaf-%s" leaf--name)))
+	       ,(intern (format ":%s" (car elm))))))
           leaf--value)
        ,@leaf--body)
 
@@ -348,8 +348,8 @@ Unlike `butlast', it works well with dotlist (last cdr is non-nil list)."
               (plist-get               ; Value.
                (cdr (plstore-get
                      ,(cdr elm)
-		     ,(concat "leaf-" (symbol-name leaf--name))))
-               ,(intern (concat ":" (symbol-name (car elm)))))))
+		     ,(format "leaf-%s" leaf--name)))
+	       ,(intern (format ":%s" (car elm))))))
           leaf--value)
        ,@leaf--body)
 

--- a/leaf.el
+++ b/leaf.el
@@ -144,8 +144,8 @@ This disabled `leaf-expand-minimally-suppress-keywords'."
 The elements of LIST are not copied, just the list structure itself."
   (if (consp list)
       (let ((res nil))
-	(while (consp list) (push (pop list) res))
-	(prog1 (nreverse res) (setcdr res list)))
+        (while (consp list) (push (pop list) res))
+        (prog1 (nreverse res) (setcdr res list)))
     (car list)))
 
 (defun leaf-safe-mapcar (fn seq)
@@ -293,7 +293,7 @@ Unlike `butlast', it works well with dotlist (last cdr is non-nil list)."
               (plist-get               ; Value.
                (cdr (plstore-get
                      ,(cdr elm)
-		     ,(format "leaf-%s" leaf--name)))
+                     ,(format "leaf-%s" leaf--name)))
                ,(intern (format ":%s" (car elm))))))
           leaf--value)
        ,@leaf--body)
@@ -314,8 +314,8 @@ Unlike `butlast', it works well with dotlist (last cdr is non-nil list)."
                 (plist-get              ; Value.
                  (cdr (plstore-get
                        ,(cdr elm)
-		       ,(format "leaf-%s" leaf--name)))
-		 ,(intern (format ":%s" (car elm))))
+                       ,(format "leaf-%s" leaf--name)))
+                 ,(intern (format ":%s" (car elm))))
                 ,(format                ; Comment.
                   "Customized in leaf `%s' from plstore `%s'"
                   leaf--name (symbol-name (cdr elm)))))
@@ -334,8 +334,8 @@ Unlike `butlast', it works well with dotlist (last cdr is non-nil list)."
               (plist-get               ; Value.
                (cdr (plstore-get
                      ,(cdr elm)
-		     ,(format "leaf-%s" leaf--name)))
-	       ,(intern (format ":%s" (car elm))))))
+                     ,(format "leaf-%s" leaf--name)))
+               ,(intern (format ":%s" (car elm))))))
           leaf--value)
        ,@leaf--body)
 
@@ -348,8 +348,8 @@ Unlike `butlast', it works well with dotlist (last cdr is non-nil list)."
               (plist-get               ; Value.
                (cdr (plstore-get
                      ,(cdr elm)
-		     ,(format "leaf-%s" leaf--name)))
-	       ,(intern (format ":%s" (car elm))))))
+                     ,(format "leaf-%s" leaf--name)))
+               ,(intern (format ":%s" (car elm))))))
           leaf--value)
        ,@leaf--body)
 

--- a/leaf.el
+++ b/leaf.el
@@ -287,15 +287,15 @@ Unlike `butlast', it works well with dotlist (last cdr is non-nil list)."
      ;; Pre-`setq' variables from a plstore.
      :pl-pre-setq
      `((setq
-	,@(mapcan
-	   (lambda (elm)
-	     `(,(car elm)		; Variable.
-	       (plist-get		; Value.
-		(cdr (plstore-get
-		      ,(cdr elm)
-		      ,(symbol-name leaf--name)))
-		,(intern (concat ":" (symbol-name (car elm)))))))
-	   leaf--value))
+        ,@(mapcan
+           (lambda (elm)
+             `(,(car elm)               ; Variable.
+               (plist-get               ; Value.
+                (cdr (plstore-get
+                      ,(cdr elm)
+                      ,(symbol-name leaf--name)))
+                ,(intern (concat ":" (symbol-name (car elm)))))))
+           leaf--value))
        ,@leaf--body)
 
      :init           `(,@leaf--value ,@leaf--body)
@@ -308,18 +308,18 @@ Unlike `butlast', it works well with dotlist (last cdr is non-nil list)."
      ;; Customize variables from a plstore.
      :pl-custom
      `((custom-set-variables
-	,@(mapcar
-	   (lambda (elm)
-	     `'(,(car elm)		; Variable.
-		(plist-get		; Value.
-		 (cdr (plstore-get
-		       ,(cdr elm)
-		       ,(symbol-name leaf--name)))
-		 ,(intern (concat ":" (symbol-name (car elm)))))
-		,(format		; Comment.
-		  "Customized in leaf `%s' from plstore `%s'"
-		  leaf--name (symbol-name (cdr elm)))))
-	   leaf--value))
+        ,@(mapcar
+           (lambda (elm)
+             `'(,(car elm)              ; Variable.
+                (plist-get              ; Value.
+                 (cdr (plstore-get
+                       ,(cdr elm)
+                       ,(symbol-name leaf--name)))
+                 ,(intern (concat ":" (symbol-name (car elm)))))
+                ,(format                ; Comment.
+                  "Customized in leaf `%s' from plstore `%s'"
+                  leaf--name (symbol-name (cdr elm)))))
+           leaf--value))
        ,@leaf--body)
 
      :setq           `(,@(mapcar (lambda (elm) `(setq ,(car elm) ,(cdr elm))) leaf--value) ,@leaf--body)
@@ -328,29 +328,29 @@ Unlike `butlast', it works well with dotlist (last cdr is non-nil list)."
      ;; `setq' variables from a plstore.
      :pl-setq
      `((setq
-	,@(mapcan
-	   (lambda (elm)
-	     `(,(car elm)		; Variable.
-	       (plist-get		; Value.
-		(cdr (plstore-get
-		      ,(cdr elm)
-		      ,(symbol-name leaf--name)))
-		,(intern (concat ":" (symbol-name (car elm)))))))
-	   leaf--value))
+        ,@(mapcan
+           (lambda (elm)
+             `(,(car elm)               ; Variable.
+               (plist-get               ; Value.
+                (cdr (plstore-get
+                      ,(cdr elm)
+                      ,(symbol-name leaf--name)))
+                ,(intern (concat ":" (symbol-name (car elm)))))))
+           leaf--value))
        ,@leaf--body)
 
      ;; `setq-default' variables from a plstore.
      :pl-setq-default
      `((setq-default
-	,@(mapcan
-	   (lambda (elm)
-	     `(,(car elm)		; Variable.
-	       (plist-get		; Value.
-		(cdr (plstore-get
-		      ,(cdr elm)
-		      ,(symbol-name leaf--name)))
-		,(intern (concat ":" (symbol-name (car elm)))))))
-	   leaf--value))
+        ,@(mapcan
+           (lambda (elm)
+             `(,(car elm)               ; Variable.
+               (plist-get               ; Value.
+                (cdr (plstore-get
+                      ,(cdr elm)
+                      ,(symbol-name leaf--name)))
+                ,(intern (concat ":" (symbol-name (car elm)))))))
+           leaf--value))
        ,@leaf--body)
 
      :config         `(,@leaf--value ,@leaf--body)
@@ -381,7 +381,7 @@ Sort by `leaf-sort-leaf--values-plist' in this order.")
                             :ensure :package
                             :hook :mode :interpreter :magic :magic-fallback :defun
                             :setq :pre-setq :setq-default :custom :custom-face
-			    :pl-setq :pl-pre-setq :pl-setq-default :pl-custom)))
+                            :pl-setq :pl-pre-setq :pl-setq-default :pl-custom)))
      ;; Accept: (sym . val), ((sym sym ...) . val), (sym sym ... . val)
      ;; Return: list of pair (sym . val)
      ;; Note  : atom ('t, 'nil, symbol) is just ignored

--- a/leaf.el
+++ b/leaf.el
@@ -283,20 +283,7 @@ Unlike `butlast', it works well with dotlist (last cdr is non-nil list)."
                          `((eval-after-load ',leaf--name '(progn ,@leaf--body))) `(,@leaf--body))
 
      :pre-setq       `(,@(mapcar (lambda (elm) `(setq ,(car elm) ,(cdr elm))) leaf--value) ,@leaf--body)
-
-     ;; Pre-`setq' variables from a plstore.
-     :pl-pre-setq
-     `(,@(mapcar
-          (lambda (elm)
-            `(setq
-              ,(car elm)               ; Variable.
-              (plist-get               ; Value.
-               (cdr (plstore-get
-                     ,(cdr elm)
-                     ,(format "leaf-%s" leaf--name)))
-               ,(intern (format ":%s" (car elm))))))
-          leaf--value)
-       ,@leaf--body)
+     :pl-pre-setq    `(,@(mapcar (lambda (elm) `(setq ,(car elm) (plist-get (cdr (plstore-get ,(cdr elm) ,(format "leaf-%s" leaf--name))) ,(intern (format ":%s" (car elm)))))) leaf--value) ,@leaf--body)
 
      :init           `(,@leaf--value ,@leaf--body)
 
@@ -304,54 +291,11 @@ Unlike `butlast', it works well with dotlist (last cdr is non-nil list)."
 
      :custom         `((custom-set-variables ,@(mapcar (lambda (elm) `'(,(car elm) ,(cdr elm) ,(format "Customized with leaf in %s block" leaf--name))) leaf--value)) ,@leaf--body)
      :custom-face    `((custom-set-faces     ,@(mapcar (lambda (elm) `'(,(car elm) ,(car (cddr elm)))) leaf--value)) ,@leaf--body)
-
-     ;; Customize variables from a plstore.
-     :pl-custom
-     `((custom-set-variables
-        ,@(mapcar
-           (lambda (elm)
-             `'(,(car elm)              ; Variable.
-                (plist-get              ; Value.
-                 (cdr (plstore-get
-                       ,(cdr elm)
-                       ,(format "leaf-%s" leaf--name)))
-                 ,(intern (format ":%s" (car elm))))
-                ,(format                ; Comment.
-                  "Customized in leaf `%s' from plstore `%s'"
-                  leaf--name (symbol-name (cdr elm)))))
-           leaf--value))
-       ,@leaf--body)
-
+     :pl-custom      `((custom-set-variables ,@(mapcar (lambda (elm) `'(,(car elm) (plist-get (cdr (plstore-get ,(cdr elm) ,(format "leaf-%s" leaf--name))) ,(intern (format ":%s" (car elm)))) ,(format "Customized in leaf `%s' from plstore `%s'" leaf--name (symbol-name (cdr elm))))) leaf--value)) ,@leaf--body)
      :setq           `(,@(mapcar (lambda (elm) `(setq ,(car elm) ,(cdr elm))) leaf--value) ,@leaf--body)
      :setq-default   `(,@(mapcar (lambda (elm) `(setq-default ,(car elm) ,(cdr elm))) leaf--value) ,@leaf--body)
-
-     ;; `setq' variables from a plstore.
-     :pl-setq
-     `(,@(mapcar
-          (lambda (elm)
-            `(setq
-              ,(car elm)               ; Variable.
-              (plist-get               ; Value.
-               (cdr (plstore-get
-                     ,(cdr elm)
-                     ,(format "leaf-%s" leaf--name)))
-               ,(intern (format ":%s" (car elm))))))
-          leaf--value)
-       ,@leaf--body)
-
-     ;; `setq-default' variables from a plstore.
-     :pl-setq-default
-     `(,@(mapcar
-          (lambda (elm)
-            `(setq-default
-              ,(car elm)               ; Variable.
-              (plist-get               ; Value.
-               (cdr (plstore-get
-                     ,(cdr elm)
-                     ,(format "leaf-%s" leaf--name)))
-               ,(intern (format ":%s" (car elm))))))
-          leaf--value)
-       ,@leaf--body)
+     :pl-setq        `(,@(mapcar (lambda (elm) `(setq ,(car elm) (plist-get (cdr (plstore-get ,(cdr elm) ,(format "leaf-%s" leaf--name))) ,(intern (format ":%s" (car elm)))))) leaf--value) ,@leaf--body)
+     :pl-setq-default `(,@(mapcar (lambda (elm) `(setq-default ,(car elm) (plist-get (cdr (plstore-get ,(cdr elm) ,(format "leaf-%s" leaf--name))) ,(intern (format ":%s" (car elm)))))) leaf--value) ,@leaf--body)
 
      :config         `(,@leaf--value ,@leaf--body)
      ))


### PR DESCRIPTION
This PR implements the following keywords: `:pl-setq`, `:pl-pre-setq`, `:pl-setq-default`, and `:pl-custom`.  The purpose is to allow setting or customizing variables from plstore.  Relevant issue is #276.

As an example, consider the following leaf

```elisp
(leaf sql
  :pl-custom
  (sql-connection-alist . my-plstore))
```

whose purpose is to customize `sql-connection-alist` with a value taken from `my-plstore`.

The contents of `my-plstore` should contain the following entry after decryption

```elisp
("sql"
 :secret-sql-connection-alist
 (("Postgres/d125q"
   (sql-product 'postgres)
   (sql-user "d125q")
   (sql-password "password")
   (sql-server "server")
   (sql-port 5432)
   (sql-database "database"))
  ("MySQL/d125q"
   (sql-product 'mysql)
   (sql-user "d125q")
   (sql-password "password")
   (sql-server "server")
   (sql-port 3306)
   (sql-database "database"))))
```