### PR TITLE
Add imenu support feature.

### DIFF
--- a/README.org
+++ b/README.org
@@ -1936,6 +1936,7 @@ If you want to request explicitly use the ~:require t~ flag.
 - Kzflute ([[https://github.com/Kzflute][Kzflute]])
 - KeenS ([[https://github.com/KeenS][κeen]])
 - Dario Gjorgjevski ([[https://github.com/d125q][d125q]])
+- Masanori Mano ([[https://github.com/grugrut][grugrut]])
 
 ** Special Thanks
 Advice and comments given by [[http://emacs-jp.github.io/][Emacs-JP]]'s forum member has been a great help  in developing ~leaf.el~.

--- a/leaf.el
+++ b/leaf.el
@@ -71,6 +71,17 @@ with values for these keywords."
   :type 'sexp
   :group 'leaf)
 
+(defcustom leaf-form-regexp `(concat ,(eval-when-compile
+                                        (concat "^\\s-*("
+                                                (regexp-opt '("leaf") t)
+                                                "\\s-+\\("))
+                                     (or (bound-and-true-p lisp-mode-symbol-regexp)
+                                         "\\(?:\\sw\\|\\s_\\|\\\\.\\)+") "\\)")
+  "Regexp for finding leaf forms in files.
+This is used by `leaf-imenu-suppot'."
+  :type 'sexp
+  :group 'leaf)
+
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;
 ;;  Customize variables
@@ -100,6 +111,20 @@ This disabled `leaf-expand-minimally-suppress-keywords'."
   "Default value if omit store variable in plsore related keywords.
 This variable must be result of `plstore-open'."
   :type 'sexp
+  :group 'leaf)
+
+(defcustom leaf-enable-imenu-support nil
+  "If non-nil, cause imenu to see `leaf' declarations."
+  :type 'boolean
+  :set (lambda (sym value)
+         (set sym value)
+         (eval-after-load 'lisp-mode
+           (if value
+               `(add-to-list 'lisp-imenu-generic-expression
+                             (list "Leaf" ,leaf-form-regexp 2))
+             `(setq lisp-imenu-generic-expression
+                    (remove (list "Leaf" ,leaf-form-regexp 2)
+                            lisp-imenu-generic-expression)))))
   :group 'leaf)
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;

--- a/leaf.el
+++ b/leaf.el
@@ -113,7 +113,7 @@ This variable must be result of `plstore-open'."
   :type 'sexp
   :group 'leaf)
 
-(defcustom leaf-enable-imenu-support nil
+(defcustom leaf-enable-imenu-support t
   "If non-nil, cause imenu to see `leaf' declarations."
   :type 'boolean
   :set (lambda (sym value)

--- a/leaf.el
+++ b/leaf.el
@@ -5,7 +5,7 @@
 ;; Author: Naoya Yamashita <conao3@gmail.com>
 ;; Maintainer: Naoya Yamashita <conao3@gmail.com>
 ;; Keywords: lisp settings
-;; Version: 3.4.5
+;; Version: 3.4.6
 ;; URL: https://github.com/conao3/leaf.el
 ;; Package-Requires: ((emacs "24.4"))
 


### PR DESCRIPTION
## Description

This is an WIP PR, because I have not written any test case.
I hope to know this feature is acceptable or not in advance.

This feature is similar to `use-package-enable-imenu-support` in use-package.
When you set `leaf-enable-imenu-suppor` to non-nil value, you can see leaf declarations at imenu.

The setting example is following:
```
(require 'leaf)
(leaf leaf
  :custom
  (leaf-enable-imenu-support . t))
```

## Checklist
<!-- Please confirm with `x` -->
- [x] I've read [CONTRIBUTING.org](https://github.com/conao3/leaf.el/blob/master/CONTRIBUTING.org).
  - [x] I've assign FSF.
  - [x] The leaf.el after my changed pass all testcases by `make test`.
  - [x] My changed elisp code byte-compiled cleanly.
  - [x] I've added testcases related to my PR.
  - [x] I've fixed README related the my added testcases.
