### PR TITLE
Fix uncountable nouns

### DIFF
--- a/README.org
+++ b/README.org
@@ -17,7 +17,7 @@
 - [[#install][Install]]
 - [[#usage][Usage]]
 - [[#customize][Customize]]
-- [[#syntaxes][Syntaxes]]
+- [[#syntax][Syntax]]
 - [[#basic-keywords][Basic keywords]]
   - [[#none-keyword][none (keyword)]]
   - [[#require-keyword][:require keyword]]
@@ -196,7 +196,7 @@ You declaratively tell the ~leaf~ to configure the package using special keyword
 - ~leaf-expand-minimally~: If nil, disable keywords that are not needed for debugging.
 - ~leaf-default-plstore~: default ~plstore~ stored variable
 
-* Syntaxes
+* Syntax
 All below examples are excerpts from [[https://github.com/conao3/leaf.el/blob/master/leaf-tests.el][leaf-tests.el]].
 
 These examples are defined in the following format.

--- a/leaf.el
+++ b/leaf.el
@@ -5,7 +5,7 @@
 ;; Author: Naoya Yamashita <conao3@gmail.com>
 ;; Maintainer: Naoya Yamashita <conao3@gmail.com>
 ;; Keywords: lisp settings
-;; Version: 3.6.4
+;; Version: 3.6.5
 ;; URL: https://github.com/conao3/leaf.el
 ;; Package-Requires: ((emacs "24.4"))
 


### PR DESCRIPTION
Fix README.org because of countability of a word.

## Description

'syntax' is uncountable.

## Checklist
<!-- Please confirm with `x` -->
- [x] I've read [CONTRIBUTING.org](https://github.com/conao3/leaf.el/blob/master/CONTRIBUTING.org).
  - [x] I've assign FSF. 🎉
  - [x] The leaf.el after my changed pass all testcases by `make test`.
  - [ ] My changed elisp code byte-compiled cleanly.
  - [ ] I've added testcases related to my PR.
  - [ ] I've fixed README related the my added testcases.
