### PR TITLE
Fix expressions in contributing.org

### DIFF
--- a/CONTRIBUTING.org
+++ b/CONTRIBUTING.org
@@ -8,7 +8,7 @@ Here is how software developers can contribute to ~leaf.el~.
 
 ** Copyright assignments
 Fill below form and send <assign@gnu.org>.
-You also find more information at org-mode [[https://orgmode.org/worg/org-contribute.html#copyright-issues][contribution page]].
+You also find more information at org-mode's [[https://orgmode.org/worg/org-contribute.html#copyright-issues][contribution page]].
 
 #+begin_example
 Please email the following information to assign@gnu.org, and we
@@ -21,7 +21,7 @@ REQUEST: SEND FORM FOR PAST AND FUTURE CHANGES
 
 [What is the name of the program or package you're contributing to?]
 
-  leaf.el, which plan to include ELPA; Emacs official package archive.
+  leaf.el, which is planned to be included in ELPA, the Emacs official package archive.
 
 [Did you copy any files or text written by someone else in these changes?
 Even if that material is free software, we need to know about it.]

--- a/leaf.el
+++ b/leaf.el
@@ -5,7 +5,7 @@
 ;; Author: Naoya Yamashita <conao3@gmail.com>
 ;; Maintainer: Naoya Yamashita <conao3@gmail.com>
 ;; Keywords: lisp settings
-;; Version: 3.6.5
+;; Version: 3.6.6
 ;; URL: https://github.com/conao3/leaf.el
 ;; Package-Requires: ((emacs "24.4"))
 


### PR DESCRIPTION
Most significant problem is that it says "leaf.el, which plan to *include* ELPA."
No! That's the opposite! :)

And what plans to do is the author. Not the thing leaf.el. So it's
better to correct it to the passive.

## Description


## Checklist
<!-- Please confirm with `x` -->
- [x] I've read [CONTRIBUTING.org](https://github.com/conao3/leaf.el/blob/master/CONTRIBUTING.org).
  - [x] I've assigned FSF.
  - [x] The leaf.el after my changed pass all testcases by `make test`.
  - [ ] My changed elisp code byte-compiled cleanly.
  - [ ] I've added testcases related to my PR.
  - [ ] I've fixed README related the my added testcases.
