### PR TITLE
feature#362

### DIFF
--- a/leaf.el
+++ b/leaf.el
@@ -5,7 +5,7 @@
 ;; Author: Naoya Yamashita <conao3@gmail.com>
 ;; Maintainer: Naoya Yamashita <conao3@gmail.com>
 ;; Keywords: lisp settings
-;; Version: 3.7.0
+;; Version: 3.7.1
 ;; URL: https://github.com/conao3/leaf.el
 ;; Package-Requires: ((emacs "24.4"))
 

--- a/leaf.el
+++ b/leaf.el
@@ -784,10 +784,10 @@ FN also accept list of FN."
   "Handler auth-* to set SYM of NAME from STORE."
   (if leaf-use-authinfo
       `(let ((res (auth-source-search :host ,(format "leaf-%s" sym))))
-        (if res
-            (funcall (plist-get (car res) :secret))
-          (error ,(format "Failed to search `leaf-%s' as machine/host name in auth-sources: '%%s" sym)
-                 auth-sources)))
+         (if res
+             (funcall (plist-get (car res) :secret))
+           (error ,(format "Failed to search `leaf-%s' as machine/host name in auth-sources: '%%s" sym)
+                  auth-sources)))
     `(if ,store
          (let ((res (cdr-safe (plstore-get ,store ,(format "leaf-%s" name)))))
            (if res


### PR DESCRIPTION
done.

If expand below leaf,
``` emacs-lisp
(ppp-macroexpand
 (leaf hoge
   :custom (x t)))
```

...expanded below (filtered related `t`),
``` emacs-lisp
(ppp-macroexpand
 (leaf hoge
   :custom (x t)))
;;=> (prog1 'hoge
;;     (custom-set-variables
;;      '(x nil "Customized with leaf in hoge block")))
```

...and user get below warnings.
``` emacs-lisp
Error (leaf): Error occurs in leaf block: hoge
Error (leaf): Attempt modify constant: t;  Please check your specification
```

This issue reported at #362.