### PR TITLE
Fix missing quote for progn with eval-after-load

### DIFF
--- a/README.org
+++ b/README.org
@@ -2343,6 +2343,7 @@ If you want to request explicitly use the ~:require t~ flag.
 - KeenS ([[https://github.com/KeenS][κeen]])
 - Dario Gjorgjevski ([[https://github.com/d125q][d125q]])
 - Masanori Mano ([[https://github.com/grugrut][grugrut]])
+- Thomas Padioleau ([[https://github.com/tpadioleau][tpadioleau]])
 
 ** Special Thanks
 Advice and comments given by [[http://emacs-jp.github.io/][Emacs-JP]]'s forum member has been a great help  in developing ~leaf.el~.

--- a/leaf-tests.el
+++ b/leaf-tests.el
@@ -2023,8 +2023,8 @@ Example:
      (prog1 'leaf
        (leaf-pre-init)
        (eval-after-load 'leaf
-         (progn
-           (leaf-init)))))
+         '(progn
+            (leaf-init)))))
 
     ((leaf leaf
        :init (leaf-init)
@@ -2034,9 +2034,9 @@ Example:
      (prog1 'leaf
        (leaf-init)
        (eval-after-load 'leaf
-         (progn
-           (leaf-pre-init)
-           (leaf-pre-init-after)))))))
+         '(progn
+            (leaf-pre-init)
+            (leaf-pre-init-after)))))))
 
 (cort-deftest-with-macroexpand leaf/auth-custom
   '(

--- a/leaf.el
+++ b/leaf.el
@@ -5,7 +5,7 @@
 ;; Author: Naoya Yamashita <conao3@gmail.com>
 ;; Maintainer: Naoya Yamashita <conao3@gmail.com>
 ;; Keywords: lisp settings
-;; Version: 4.2.4
+;; Version: 4.2.5
 ;; URL: https://github.com/conao3/leaf.el
 ;; Package-Requires: ((emacs "24.4"))
 

--- a/leaf.el
+++ b/leaf.el
@@ -156,7 +156,7 @@ Same as `list' but this macro does not evaluate any arguments."
    :pl-setq-default   `(,@(mapcar (lambda (elm) `(setq-default ,(car elm) (leaf-handler-auth ,leaf--name ,(car elm) ,(cdr elm)))) leaf--value) ,@leaf--body)
    :auth-setq-default `(,@(mapcar (lambda (elm) `(setq-default ,(car elm) (leaf-handler-auth ,leaf--name ,(car elm) ,(cdr elm)))) leaf--value) ,@leaf--body)
    :config            `(,@leaf--value ,@leaf--body)
-   :defer-config      `((eval-after-load ',leaf--name (progn ,@leaf--value)) ,@leaf--body))
+   :defer-config      `((eval-after-load ',leaf--name '(progn ,@leaf--value)) ,@leaf--body))
   "Special keywords and conversion rule to be processed by `leaf'.
 Sort by `leaf-sort-leaf--values-plist' in this order.")
 


### PR DESCRIPTION
## Description

Fix missing quote for progn with new `:defer-config` as in `:leaf-defer` case.