### PR TITLE
defun -> defsubst; leaf-this-file is expanded in :leaf-path Sexp

### DIFF
--- a/leaf.el
+++ b/leaf.el
@@ -636,7 +636,7 @@ see `alist-get'."
    (when load-file-name
      (format " at `%s'" load-file-name))))
 
-(defun leaf-this-file ()
+(defsubst leaf-this-file ()
   "Return path to this file."
   (or leaf--load-file-name
       load-file-name


### PR DESCRIPTION
`leaf-this-file` appears after the :leaf-path, whith requires
`(require 'leaf)` thus spoiling the feature of `leaf`.

Definding `leaf-this-file` using `defsubst` instead of `defun`
prevents the funciton being expanded directly after macro expansion.

This issue was reported in #497.