### PR TITLE
On :package, save already installed pkgs into selected-packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -396,11 +396,13 @@ Since `:ensure` is to use `package.el` by default, `:ensure` and `:package` prod
      (prog1 'macrostep
        (leaf-handler-package macrostep macrostep nil)))
 
-    ;; `leaf-handler-package' expandion example.
-    ;; If `macrostep' isn't installed, try to install.
-    ;; If fail install, update local cache and retry to install.
+    ;; `leaf-handler-package' expansion example.
+    ;; If `macrostep' is installed, set it as a selected package;
+    ;; otherwise try to install it.
+    ;; If installation fails, update local cache and retry to install.
     ((leaf-handler-package macrostep macrostep nil)
-     (unless (package-installed-p 'macrostep)
+     (if (package-installed-p 'macrostep)
+         (package--update-selected-packages '(macrostep) nil)
        (unless (assoc 'macrostep package-archive-contents)
          (package-refresh-contents))
        (condition-case err

--- a/README.org
+++ b/README.org
@@ -414,11 +414,13 @@ Since ~:ensure~ is to use ~package.el~ by default, ~:ensure~ and
        (prog1 'macrostep
          (leaf-handler-package macrostep macrostep nil)))
 
-      ;; `leaf-handler-package' expandion example.
-      ;; If `macrostep' isn't installed, try to install.
-      ;; If fail install, update local cache and retry to install.
+      ;; `leaf-handler-package' expansion example.
+      ;; If `macrostep' is installed, set it as a selected package;
+      ;; otherwise try to install it.
+      ;; If installation fails, update local cache and retry to install.
       ((leaf-handler-package macrostep macrostep nil)
-       (unless (package-installed-p 'macrostep)
+       (if (package-installed-p 'macrostep)
+           (package--update-selected-packages '(macrostep) nil)
          (unless (assoc 'macrostep package-archive-contents)
            (package-refresh-contents))
          (condition-case err

--- a/leaf-tests.el
+++ b/leaf-tests.el
@@ -2385,11 +2385,13 @@ Example:
      (prog1 'macrostep
        (leaf-handler-package macrostep macrostep nil)))
 
-    ;; `leaf-handler-package' expandion example.
-    ;; If `macrostep' isn't installed, try to install.
-    ;; If fail install, update local cache and retry to install.
+    ;; `leaf-handler-package' expansion example.
+    ;; If `macrostep' is installed, set it as a selected package;
+    ;; otherwise try to install it.
+    ;; If installation fails, update local cache and retry to install.
     ((leaf-handler-package macrostep macrostep nil)
-     (unless (package-installed-p 'macrostep)
+     (if (package-installed-p 'macrostep)
+         (package--update-selected-packages '(macrostep) nil)
        (unless (assoc 'macrostep package-archive-contents)
          (package-refresh-contents))
        (condition-case _err

--- a/leaf.el
+++ b/leaf.el
@@ -1074,8 +1074,10 @@ FN also accept list of FN."
       (add-to-list 'leaf--paths (cons ',name file)))))
 
 (defmacro leaf-handler-package (name pkg _pin)
-  "Handler ensure PKG via PIN in NAME leaf block."
-  `(unless (package-installed-p ',pkg)
+  "Handler for ensuring the installation of PKG with package.el
+via PIN in the leaf block NAME."
+  `(if (package-installed-p ',pkg)
+       (package--update-selected-packages '(,pkg) nil)
      (unless (assoc ',pkg package-archive-contents)
        (package-refresh-contents))
      (condition-case _err


### PR DESCRIPTION
## Description

<!-- Please write a description of your PR -->


Make sure the `:package`'s target packages are always saved into
the variable `packages-selected-packages`, whether or not
the packages are already installed. This way we can more easily
use package.el-related utilities like `package-autoremove`.


Fixes #504
Fixes #294


## Checklist
<!-- Please confirm with `x` -->
- [x] I've read [CONTRIBUTING.org](https://github.com/conao3/leaf.el/blob/master/CONTRIBUTING.org).
  - [x] I've assigned my copyright to FSF.
  - [x] The leaf.el after my changed pass all testcases by `make test`.
  - [x] My changed elisp code byte-compiled cleanly.
  - [x] I've added testcases related to my PR.
  - [x] I've fixed README related the my added testcases.
