### PR TITLE
Use just push instead of using package--save-selected-packages

### DIFF
--- a/leaf-tests.el
+++ b/leaf-tests.el
@@ -2390,21 +2390,21 @@ Example:
     ;; otherwise try to install it.
     ;; If installation fails, update local cache and retry to install.
     ((leaf-handler-package macrostep macrostep nil)
-     (if (package-installed-p 'macrostep)
-         (package--update-selected-packages '(macrostep) nil)
-       (unless (assoc 'macrostep package-archive-contents)
-         (package-refresh-contents))
-       (condition-case _err
-           (package-install 'macrostep)
-         (error
-          (condition-case err
-              (progn
-                (package-refresh-contents)
-                (package-install 'macrostep))
-            (error
-             (display-warning 'leaf
-                              (format "In `macrostep' block, failed to :package of `macrostep'.  Error msg: %s"
-                                      (error-message-string err)))))))))))
+     (progn
+       (leaf-safe-push 'macrostep package-selected-packages 'no-dup)
+       (unless (package-installed-p 'macrostep)
+         (unless (assoc 'macrostep package-archive-contents)
+           (package-refresh-contents))
+         (condition-case _err
+             (package-install 'macrostep)
+           (error
+            (package-refresh-contents)
+            (condition-case err
+                (package-install 'macrostep)
+              (error
+               (display-warning 'leaf
+                                (format "In `macrostep' block, failed to :package of `macrostep'.  Error msg: %s"
+                                        (error-message-string err))))))))))))
 
 (when (version< "24.0" emacs-version)
   (cort-deftest-with-macroexpand leaf/leaf-key

--- a/leaf.el
+++ b/leaf.el
@@ -5,7 +5,7 @@
 ;; Author: Naoya Yamashita <conao3@gmail.com>
 ;; Maintainer: Naoya Yamashita <conao3@gmail.com>
 ;; Keywords: lisp settings
-;; Version: 4.5.2
+;; Version: 4.5.3
 ;; URL: https://github.com/conao3/leaf.el
 ;; Package-Requires: ((emacs "24.1"))
 


### PR DESCRIPTION
## Description

```
   use just `push` instead of using `package--update-selected-packages`

   Note
   - The previous function expanded `custom-save-variable`, which
    saved custom.el sequentially, causing serious performance
    degradation in some cases.

   - Since `package-selected-packages` was introduced in Emacs-25.1,
    we will consider the case where this variable is not declared.
    If it is not declared, just `setq` it as a new variable. (leaf-safe-push)

   - Remove progn from the second `condition-case`, since
    it can accept multiple S-expressions in the error arm.
```

## Checklist