### PR TITLE
Fix typo (isearch-mode-map)

### DIFF
--- a/README.md
+++ b/README.md
@@ -770,7 +770,7 @@ If you omit `:package`, use leaf--name as `:package` to lazy load.
                     ("M-o" . isearch-moccur)
                     ("M-O" . isearch-moccur-all))))))
 
-    ;; use :package to deffering :iserch-mode-map declared
+    ;; use :package to deffering :isearch-mode-map declared
     ((leaf color-moccur
        :bind (("M-s O" . moccur)
               (:isearch-mode-map
@@ -925,7 +925,7 @@ Basic usage is same as `:bind` and `:bind*`
 			                            ("C-%" . ctl-x-5-map)))
                               nil 'projectile)))
 
-    ;; use :package to deffering :iserch-mode-map declared
+    ;; use :package to deffering :isearch-mode-map declared
     ((leaf projectile
        :bind-keymap (("C-c p" . projectile-command-map)
                      (:isearch-mode-map

--- a/README.org
+++ b/README.org
@@ -782,7 +782,7 @@ If you omit ~:package~, use leaf--name as ~:package~ to lazy load.
                       ("M-o" . isearch-moccur)
                       ("M-O" . isearch-moccur-all))))))
 
-      ;; use :package to deffering :iserch-mode-map declared
+      ;; use :package to deffering :isearch-mode-map declared
       ((leaf color-moccur
          :bind (("M-s O" . moccur)
                 (:isearch-mode-map
@@ -992,7 +992,7 @@ Basic usage is same as ~:bind~ and ~:bind*~
                       ("M-o" . isearch-moccur)
                       ("M-O" . isearch-moccur-all))))))
 
-      ;; use :package to deffering :iserch-mode-map declared
+      ;; use :package to deffering :isearch-mode-map declared
       ((leaf color-moccur
          :bind (("M-s O" . moccur)
                 (:isearch-mode-map

--- a/leaf-tests.el
+++ b/leaf-tests.el
@@ -1113,7 +1113,7 @@ Example:
                     ("M-o" . isearch-moccur)
                     ("M-O" . isearch-moccur-all))))))
 
-    ;; use :package to deffering :iserch-mode-map declared
+    ;; use :package to deffering :isearch-mode-map declared
     ((leaf color-moccur
        :bind (("M-s O" . moccur)
               (:isearch-mode-map
@@ -1293,7 +1293,7 @@ Example:
 			                            ("C-%" . ctl-x-5-map)))
                               nil 'projectile)))
 
-    ;; use :package to deffering :iserch-mode-map declared
+    ;; use :package to deffering :isearch-mode-map declared
     ((leaf projectile
        :bind-keymap (("C-c p" . projectile-command-map)
                      (:isearch-mode-map


### PR DESCRIPTION
## Description

Fix typo (isearch-mode-map)

## Checklist

- [x] I've read [CONTRIBUTING.org](https://github.com/conao3/leaf.el/blob/master/CONTRIBUTING.org).
  - [x] I've assign FSF.
  - [ ] The leaf.el after my changed pass all testcases by `make test`.
  - [ ] My changed elisp code byte-compiled cleanly.
  - [ ] I've added testcases related to my PR.
  - [ ] I've fixed README related the my added testcases.
