### PR TITLE
Remove extra quote before (lambda) generated by `leaf-key`.

### DIFF
--- a/leaf-tests.el
+++ b/leaf-tests.el
@@ -2454,7 +2454,7 @@ Example:
        (let* ((old (lookup-key global-map (kbd "M-s O")))
               (value `(global-map "M-s O" *lambda-function* ,(and old (not (numberp old)) old) nil)))
          (leaf-safe-push value leaf-key-bindlist)
-         (define-key global-map (kbd "M-s O") '(lambda () "color-moccur" (interactive) (color-moccur)))))
+         (define-key global-map (kbd "M-s O") (lambda () "color-moccur" (interactive) (color-moccur)))))
 
       ((leaf-key "M-s O" '(menu-item "" nil :filter (lambda (&optional _) #'other-window)))
        (let* ((old (lookup-key global-map (kbd "M-s O")))

--- a/leaf.el
+++ b/leaf.el
@@ -858,7 +858,8 @@ For example:
     `(let* ((old (lookup-key ,mmap ,(if vecp key* `(kbd ,key*))))
             (value ,(list '\` `(,mmap ,mstr ,bindto ,',(and old (not (numberp old)) old) ,path))))
        (leaf-safe-push value leaf-key-bindlist)
-       (define-key ,mmap ,(if vecp key* `(kbd ,key*)) ',command*))))
+       (define-key ,mmap ,(if vecp key* `(kbd ,key*))
+                   ,(if (eq bindto '*lambda-function*) command* `',command*)))))
 
 (defmacro leaf-key* (key command)
   "Similar to `leaf-key', but overrides any mode-specific bindings.


### PR DESCRIPTION
## Description

when bind key like this:
```elisp
(leaf-key "<f5>" (lambda () (interactive) (message "hello")))
```

It will warn when startup like this:
```
Warning: (lambda nil \.\.\.) quoted with ' rather than with #'
```

Remove extra ' before lambda resolve it.

## Checklist
<!-- Please confirm with `x` -->
- [x] I've read [CONTRIBUTING.org](https://github.com/conao3/leaf.el/blob/master/CONTRIBUTING.org).
  - [x] I've assign FSF.
  - [x] The leaf.el after my changed pass all testcases by `make test`.
  - [x] My changed elisp code byte-compiled cleanly.
  - [ ] I've added testcases related to my PR.
  - [ ] I've fixed README related the my added testcases.
