### PR TITLE
Get rid the warning in define minor mode.

### DIFF
--- a/leaf.el
+++ b/leaf.el
@@ -832,7 +832,8 @@ If NO-DUP is non-nil, do not `push' if the element already exists."
 
 (define-minor-mode leaf-key-override-global-mode
   "A minor mode so that keymap settings override other modes."
-  t "")
+  :init-value t
+  :lighter "")
 
 ;; the keymaps in `emulation-mode-map-alists' take precedence over
 ;; `minor-mode-map-alist'


### PR DESCRIPTION
## Description

The warning is `Use keywords rather than deprecated positional arguments to define-minor-mode`
when startup.

## Checklist
<!-- Please confirm with `x` -->
- [x] I've read [CONTRIBUTING.org](https://github.com/conao3/leaf.el/blob/master/CONTRIBUTING.org).
- [x] I've assign FSF.
- [x] The leaf.el after my changed pass all testcases by `make test`.
- [x] My changed elisp code byte-compiled cleanly.
- [ ] I've added testcases related to my PR.
- [ ] I've fixed README related the my added testcases.
