### PR TITLE
leaf-handler-vc: Add package to package-selected-packages

### DIFF
--- a/leaf.el
+++ b/leaf.el
@@ -1119,10 +1119,12 @@ SPEC is a list of the form (PKG OPTIONS REVISION)"
   (let ((pkg (nth 0 spec))
         (opts (nth 1 spec))
         (rev (nth 2 spec)))
-    `(unless (package-installed-p ',pkg)
-       (package-vc-install
-        ',(if opts `(,pkg ,@opts) pkg)
-        ,rev))))
+    `(progn
+       (leaf-safe-push ',pkg package-selected-packages 'no-dup)
+       (unless (package-installed-p ',pkg)
+         (package-vc-install
+          ',(if opts `(,pkg ,@opts) pkg)
+          ,rev)))))
 
 (defmacro leaf-handler-auth (name sym store)
   "Handler auth-* to set SYM of NAME from STORE."


### PR DESCRIPTION
## Description

The `:vc` handler (`leaf-handler-vc`) previously only called `package-vc-install` but did not update `package-selected-packages`. This caused packages installed via `:vc` to be flagged as orphaned by `package-autoremove`.

This commit adds a `leaf-safe-push` call to `leaf-handler-vc`, aligning its behavior with `leaf-handler-package`. This ensures that VC-installed packages are correctly registered in the in-memory session, preventing them from being unexpectedly removed during package cleanup.

```emacs-lisp
;; Before
(leaf-handler-vc bbdb (bbdb (:url "..." :lisp-dir "...")))
;; => (unless (package-installed-p 'bbdb) (package-vc-install '(bbdb ...) nil))
```
```emacs-lisp
;; After
(leaf-handler-vc bbdb (bbdb (:url "..." :lisp-dir "...")))
;; => (progn
;;      (leaf-safe-push 'bbdb package-selected-packages 'no-dup)
;;      (unless (package-installed-p 'bbdb) (package-vc-install '(bbdb ...) nil)))
```

## Checklist
<!-- Please confirm with `x` -->
- [x]  I've read [CONTRIBUTING.org](https://github.com/conao3/leaf.el/blob/master/CONTRIBUTING.org).
  - [ ] I've assign FSF.   -> I alerady send e-mail, wating response.
  - [x] The leaf.el after my changed pass all testcases by `make test`.
  - [x] My changed elisp code byte-compiled cleanly.
  - [ ]  I've added testcases related to my PR.
    - No. Because current test suites do not check for leaf handler-* macro expansion.
  - [ ] I've fixed README related the my added testcases.
    - No. Because I didn't add any test casees.
